### PR TITLE
Update travis-ci badge image and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # dummy-CI-Test
 
-[![Build Status](https://travis-ci.org/eliottparis/dummy-CI-Test.svg?branch=master)](https://travis-ci.org/eliottparis/dummy-CI-Test)
+[![Build Status](https://app.travis-ci.com/eliottparis/dummy-CI-Test.svg?branch=master)](https://app.travis-ci.com/github/eliottparis/dummy-CI-Test)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/eliottparis/dummy-CI-Test?branch=master&svg=true)](https://ci.appveyor.com/project/eliottparis/dummy-CI-Test/branch/master)


### PR DESCRIPTION
Since June 15th, 2021, the building on travis-ci.org is ceased. We now need to use travis-ci.com from now on.

We did the migration from the Travis app.

This PR updates the readme badge to point to the travis.com website.