### PR TITLE
Travis/build pull request on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 dist: focal
 
-branches:
-   only:
-      - master
-
 
 matrix:
    include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: focal
 
+if: (type = pull_request AND branch = master)
 
 matrix:
    include:


### PR DESCRIPTION
This PR triggers Travis-ci only on pull-request on the master branch.

In particular:

- Builds are not triggered on pushes (#3)
- Builds are only triggered on PR that tries to be merged on the `master` branch (#5)
- Merge commit does not trigger a build ([example](https://github.com/eliottparis/dummy-CI-Test/tree/9b701b3d25f4b0795c19afbe2b30b4c454e7017c))
- cron jobs do not trigger a build

![Screenshot 2021-10-01 at 17 18 52](https://user-images.githubusercontent.com/1750257/135645526-5e9a1630-0035-4a2d-a3db-975f99dabeae.png)

