### PR TITLE
Allow cron tasks to trigger builds on master on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: focal
 
-if: (type = pull_request AND branch = master)
+if: (branch = master AND (type = pull_request OR type = cron))
 
 matrix:
    include:


### PR DESCRIPTION
This PR allows builds to be triggered by CRON tasks on the `master` branch.

![Screenshot 2021-10-01 at 17 35 01](https://user-images.githubusercontent.com/1750257/135647851-b7764ad3-1314-40a6-b2cb-90b1a03bf09a.png)


